### PR TITLE
Update steering normalization

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -187,7 +187,7 @@ static int get_normalized_position( unsigned long axis_index, double * const nor
         if ( axis_index == JOYSTICK_AXIS_STEER )
         {
             ( *normalized_position ) = CONSTRAIN(
-            ((double) axis_position) / UINT16_MAX,
+            ((double) axis_position) / INT16_MAX,
             -1.0,
             1.0);
         }


### PR DESCRIPTION
Prior to this commit, the steering was being normalized over the range of UINT16_MAX, which was only allowing it to go from [-0.5, 0.5]. This commit updates it to normalize over INT16_MAX which allows for a range of [-1.0, 1.0].