### PR TITLE
Improve usability

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -80,7 +80,7 @@ int commander_init( int channel )
 
             return_code = joystick_init( );
 
-            printf( "waiting for joystick controls to zero\n" );
+            printf( "Waiting for joystick controls to zero\n" );
 
             while ( return_code != OSCC_ERROR )
             {
@@ -96,6 +96,8 @@ int commander_init( int channel )
                 }
                 else
                 {
+                    printf( "Joystick controls successfully initialized\n" );
+
                     break;
                 }
             }
@@ -195,7 +197,7 @@ static int get_normalized_position( unsigned long axis_index, double * const nor
         {
             ( *normalized_position ) = CONSTRAIN(
             ((double) axis_position) / INT16_MAX,
-            0.0, 
+            0.0,
             1.0);
         }
     }

--- a/src/commander.c
+++ b/src/commander.c
@@ -124,37 +124,45 @@ void commander_close( int channel )
 
 int check_for_controller_update( )
 {
-    unsigned int disable_button = 0;
+    static unsigned int disable_button_previous = 0;
+    unsigned int disable_button_current = 0;
 
     int return_code = joystick_update( );
 
     if ( return_code == OSCC_OK )
     {
         return_code = get_button( JOYSTICK_BUTTON_DISABLE_CONTROLS,
-                                  &disable_button );
+                                  &disable_button_current );
     }
 
     if ( return_code == OSCC_OK )
     {
-        if ( disable_button != 0 )
+        if ( (disable_button_previous != 1)
+            && (disable_button_current != 0 ) )
         {
             return_code = commander_disable_controls( );
         }
+
+        disable_button_previous = disable_button_current;
     }
 
-    unsigned int enable_button = 0;
+    static unsigned int enable_button_previous = 0;
+    unsigned int enable_button_current = 0;
 
     if ( return_code == OSCC_OK )
     {
             return_code = get_button( JOYSTICK_BUTTON_ENABLE_CONTROLS,
-                                      &enable_button );
+                                      &enable_button_current );
 
             if ( return_code == OSCC_OK )
             {
-                if ( enable_button != 0 )
+                if ( (enable_button_previous != 1)
+                    && (enable_button_current != 0 ) )
                 {
                     return_code = commander_enable_controls( );
                 }
+
+                enable_button_previous = enable_button_current;
             }
     }
 
@@ -245,10 +253,11 @@ static int commander_disable_controls( )
 {
     int return_code = OSCC_ERROR;
 
-    printf( "Disable controls\n" );
-
-    if ( commander_enabled == COMMANDER_ENABLED )
+    if ( (commander_enabled == COMMANDER_ENABLED)
+        && (control_enabled == true) )
     {
+        printf( "Disable controls\n" );
+
         return_code = oscc_disable();
 
         if ( return_code == OSCC_OK )
@@ -256,6 +265,11 @@ static int commander_disable_controls( )
             control_enabled = false;
         }
     }
+    else
+    {
+        return_code = OSCC_OK;
+    }
+
     return return_code;
 }
 
@@ -263,10 +277,11 @@ static int commander_enable_controls( )
 {
     int return_code = OSCC_ERROR;
 
-    printf( "Enable controls\n" );
-
-    if ( commander_enabled == COMMANDER_ENABLED )
+    if ( (commander_enabled == COMMANDER_ENABLED)
+        && (control_enabled == false) )
     {
+        printf( "Enable controls\n" );
+
         return_code = oscc_enable();
 
         if ( return_code == OSCC_OK )
@@ -274,6 +289,11 @@ static int commander_enable_controls( )
             control_enabled = true;
         }
     }
+    else
+    {
+        return_code = OSCC_OK;
+    }
+
     return ( return_code );
 }
 

--- a/src/commander.c
+++ b/src/commander.c
@@ -187,7 +187,7 @@ static int get_normalized_position( unsigned long axis_index, double * const nor
         if ( axis_index == JOYSTICK_AXIS_STEER )
         {
             ( *normalized_position ) = CONSTRAIN(
-            ((double) axis_position) / UINT16_MAX,
+            ((double) axis_position) / INT16_MAX,
             -1.0,
             1.0);
         }

--- a/src/main.c
+++ b/src/main.c
@@ -62,6 +62,13 @@ int main( int argc, char **argv )
 
     if ( ret == OSCC_OK )
     {
+        printf( "\nControl Ready:\n" );
+        printf( "    START - Enable controls\n" );
+        printf( "    BACK - Disable controls\n" );
+        printf( "    LEFT TRIGGER - Brake\n" );
+        printf( "    RIGHT TRIGGER - Throttle\n" );
+        printf( "    LEFT STICK - Steering\n" );
+
         while ( ret == OSCC_OK && error_thrown == OSCC_OK )
         {
             elapsed_time = get_elapsed_time( update_timestamp );


### PR DESCRIPTION
Adds print statements after control initialization to alert the user that control is ready to go, and what the controls are.

Fixes the issue where a single enable or disable button press was registered multiple times.

Resolves #8
Resolves #10 