### PR TITLE
Update CMake and add Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "oscc"]
+	path = oscc
+	url = https://github.com/PolySync/oscc.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,7 @@ project(oscc-joystick-commander)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(SDL2 REQUIRED sdl2)
 
-if(KIA_SOUL)
-    add_definitions(-DKIA_SOUL)
-elseif(KIA_SOUL_EV)
-    add_definitions(-DKIA_SOUL_EV)
-endif()
+include(oscc/api/OsccConfig.cmake)
 
 add_executable(
     oscc-joystick-commander
@@ -29,4 +25,3 @@ target_link_libraries(
     oscc-joystick-commander
     PRIVATE
     ${SDL2_LIBRARIES})
-

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cd oscc-joystick-commander
 From within the joystick commander directory, clone the OSCC repo:
 
 ```
-git clone git@github.com:PolySync/oscc.git --branch master
+git submodule update --init
 ```
 
 This will clone into a directory called `oscc` where CMake will look for the OSCC API when it builds joystick commander.


### PR DESCRIPTION
This pull request replaces the ifdef block with the osccConfig.cmake file and adds oscc as a submodule to keep the dependencies accurate.